### PR TITLE
[#5]; feat: article update api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@
 hs_err_pid*
 replay_pid*
 backend_mentoring/data/testdb.mv.db
+backend_mentoring/data/testdb.mv.db

--- a/backend_mentoring/src/main/java/com/jihuni/backend_mentoring/config/SecurityConfig.java
+++ b/backend_mentoring/src/main/java/com/jihuni/backend_mentoring/config/SecurityConfig.java
@@ -20,7 +20,7 @@ public class SecurityConfig {
         http
             .csrf(csrf -> csrf.disable()) // ✅ 전체 CSRF 비활성화
             .authorizeHttpRequests(auth -> auth
-                .requestMatchers("/", "/signup", "/h2-console/**", "/article").permitAll()
+                .requestMatchers("/", "/signup", "/h2-console/**", "/article", "/update", "/update/**").permitAll()
                 .anyRequest().authenticated()
             )
             .formLogin(form -> form.disable())

--- a/backend_mentoring/src/main/java/com/jihuni/backend_mentoring/controller/ArticleController.java
+++ b/backend_mentoring/src/main/java/com/jihuni/backend_mentoring/controller/ArticleController.java
@@ -2,7 +2,6 @@ package com.jihuni.backend_mentoring.controller;
 
 import com.jihuni.backend_mentoring.dto.ArticleRequestDto;
 import com.jihuni.backend_mentoring.dto.ArticleResponseDto;
-import com.jihuni.backend_mentoring.entity.Article;
 import com.jihuni.backend_mentoring.service.ArticleService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -16,14 +15,16 @@ public class ArticleController {
     private final ArticleService articleService;
 
     @PostMapping("/article")
-    public ResponseEntity<?> createArticle(@Valid @RequestBody ArticleRequestDto requestDto) {
-        try {
-            Article saved = articleService.createArticle(requestDto);
-            return ResponseEntity.ok(ArticleResponseDto.fromEntity(saved));
-        } catch (IllegalArgumentException e) {
-            return ResponseEntity.badRequest().body(
-                    java.util.Map.of("error", e.getMessage())
-            );
-        }
+    public ResponseEntity<ArticleResponseDto> createArticle(@Valid @RequestBody ArticleRequestDto requestDto) {
+        ArticleResponseDto responseDto = articleService.createArticle(requestDto);
+        return ResponseEntity.ok(responseDto);
+    }
+    @PutMapping("/update/{id}")
+    public ResponseEntity<ArticleResponseDto> updateArticle(
+            @PathVariable Long id,
+            @Valid @RequestBody ArticleRequestDto requestDto) {
+
+        ArticleResponseDto responseDto = articleService.updateArticle(id, requestDto);
+        return ResponseEntity.ok(responseDto);
     }
 }

--- a/backend_mentoring/src/main/java/com/jihuni/backend_mentoring/exception/GlobalExceptionHandler.java
+++ b/backend_mentoring/src/main/java/com/jihuni/backend_mentoring/exception/GlobalExceptionHandler.java
@@ -13,8 +13,7 @@ public class GlobalExceptionHandler {
 
     // 예: 잘못된 요청 (IllegalArgumentException)
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException e,
-                                                               HttpServletRequest request) {
+    public ResponseEntity<ErrorResponse> handleIllegalArgument(IllegalArgumentException e, HttpServletRequest request) {
         ErrorResponse error = new ErrorResponse(
                 LocalDateTime.now(),
                 HttpStatus.BAD_REQUEST.name(),
@@ -26,8 +25,7 @@ public class GlobalExceptionHandler {
 
     // 예: 기본 처리 (그 외 모든 예외)
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorResponse> handleException(Exception e,
-                                                         HttpServletRequest request) {
+    public ResponseEntity<ErrorResponse> handleException(Exception e, HttpServletRequest request) {
         ErrorResponse error = new ErrorResponse(
                 LocalDateTime.now(),
                 HttpStatus.INTERNAL_SERVER_ERROR.name(),

--- a/backend_mentoring/src/main/java/com/jihuni/backend_mentoring/service/ArticleService.java
+++ b/backend_mentoring/src/main/java/com/jihuni/backend_mentoring/service/ArticleService.java
@@ -1,6 +1,7 @@
 package com.jihuni.backend_mentoring.service;
 
 import com.jihuni.backend_mentoring.dto.ArticleRequestDto;
+import com.jihuni.backend_mentoring.dto.ArticleResponseDto;
 import com.jihuni.backend_mentoring.entity.Article;
 import com.jihuni.backend_mentoring.entity.User;
 import com.jihuni.backend_mentoring.repository.ArticleRepository;
@@ -8,6 +9,7 @@ import com.jihuni.backend_mentoring.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import jakarta.transaction.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -17,7 +19,7 @@ public class ArticleService {
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
-    public Article createArticle(ArticleRequestDto dto) {
+    public ArticleResponseDto createArticle(ArticleRequestDto dto) {
         User user = userRepository.findByEmail(dto.getEmail())
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
 
@@ -27,10 +29,43 @@ public class ArticleService {
 
         Article article = new Article();
         article.setEmail(dto.getEmail());
-        article.setPassword(dto.getPassword()); 
+        article.setPassword(dto.getPassword());
         article.setTitle(dto.getTitle());
         article.setContent(dto.getContent());
 
-        return articleRepository.save(article);
+        Article saved = articleRepository.save(article);
+
+
+        return ArticleResponseDto.fromEntity(saved);
     }
+    @Transactional
+    public ArticleResponseDto updateArticle(Long id, ArticleRequestDto dto) {
+        // 1. 게시글 조회
+        Article article = articleRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
+
+        // 2. 사용자 조회
+        User user = userRepository.findByEmail(dto.getEmail())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
+
+        // 3. 비밀번호 검증
+        if (!passwordEncoder.matches(dto.getPassword(), user.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        // 4. 본인 글 확인 (email 비교)
+        if (!article.getEmail().equals(user.getEmail())) {
+            throw new IllegalArgumentException("자신의 게시글만 수정할 수 있습니다.");
+        }
+
+        // 5. 수정
+        article.setTitle(dto.getTitle());
+        article.setContent(dto.getContent());
+
+        // 6. DTO 변환 후 반환
+        return ArticleResponseDto.fromEntity(article);
+    }
+
+
+    
 }


### PR DESCRIPTION
- update/{id} 형태의 url로 json전달시 게시글의 id와 email, password를 비교하여 유효성 검사
- Entity를 바로받는것이 아닌 ArticleResponseDto로 감싸서 받도록..(Contoller에서)
- 오류메세지는 GlobalExceptionHandler에서 관리한대로 뱉도록


- Transactional라는 어노테이션을 사용 (GPT추천 -> 공부)
뭔가 뭔가 아직 완벽하게 이해하진 못했지만
게임 업데이트 하다가 강종되었을때 업데이트 중간부분부터 시작 -> Transactional없음
이러면 파일충돌 날 가능성, 개발상에서 문제가없더라도 인지못할 버그가일어날수도
특히 교환이 많이 일어나는 온라인페이지에서는 치명적으로 발생할수도!!

게임 업데이트 하다가 강종되었을때 다시 처음부터 시작해버림-> Transactional
중간에 끊겼을때 그냥 처음으로 돌아가버리게 구조를 짤수있음
게시글 수정작업은 id로 조회, 사용자검증, 게시글 수정이라는 순차적인 작업이 진행되어서
중간에 끊기거나 에러가 나면 중간지점이 반영되어버리는 이상한 상황이 발생할 수 있음
따라서 써야한다..?