### PR TITLE
[#11]; feat: article delete api

### DIFF
--- a/backend_mentoring/src/main/java/com/jihuni/backend_mentoring/controller/ArticleController.java
+++ b/backend_mentoring/src/main/java/com/jihuni/backend_mentoring/controller/ArticleController.java
@@ -31,4 +31,15 @@ public class ArticleController {
         ArticleResponseDto responseDto = articleService.updateArticle(id, requestDto);
         return ResponseEntity.ok(responseDto);
     }
+
+    // 게시글 삭제: DELETE /article/delete/{id}
+    @DeleteMapping("/delete/{id}")
+    public ResponseEntity<String> deleteArticle(
+            @PathVariable Long id,
+            @RequestBody ArticleRequestDto requestDto) {
+
+        articleService.deleteArticle(id, requestDto);
+        return ResponseEntity.ok("게시글 및 댓글이 삭제되었습니다.");
+    }
+
 }

--- a/backend_mentoring/src/main/java/com/jihuni/backend_mentoring/entity/Article.java
+++ b/backend_mentoring/src/main/java/com/jihuni/backend_mentoring/entity/Article.java
@@ -1,5 +1,8 @@
 package com.jihuni.backend_mentoring.entity;
 
+import java.util.ArrayList;
+import java.util.List;  
+import com.jihuni.backend_mentoring.entity.Comment; 
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -25,4 +28,8 @@ public class Article {
 
     @Column(nullable = false)
     private String content;
+
+    @OneToMany(mappedBy = "article", cascade = CascadeType.REMOVE, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
+
 }

--- a/backend_mentoring/src/main/java/com/jihuni/backend_mentoring/service/ArticleService.java
+++ b/backend_mentoring/src/main/java/com/jihuni/backend_mentoring/service/ArticleService.java
@@ -66,6 +66,29 @@ public class ArticleService {
         return ArticleResponseDto.fromEntity(article);
     }
 
+    @Transactional
+    public void deleteArticle(Long id, ArticleRequestDto dto) {
+        // 1. 게시글 조회
+        Article article = articleRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("게시글을 찾을 수 없습니다."));
+
+        // 2. 사용자 조회
+        User user = userRepository.findByEmail(dto.getEmail())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 이메일입니다."));
+
+        // 3. 비밀번호 검증
+        if (!passwordEncoder.matches(dto.getPassword(), user.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        // 4. 본인 글 확인 (email 비교)
+        if (!article.getEmail().equals(user.getEmail())) {
+            throw new IllegalArgumentException("자신의 게시글만 삭제할 수 있습니다.");
+        }
+
+        // 5. 삭제 (댓글은 cascade = REMOVE 덕분에 자동 삭제)
+        articleRepository.delete(article);
+    }
 
     
 }


### PR DESCRIPTION
- controller : article/delete/{id} 형태의 url받기, service 기능과 연결
- service : 유효성 검사후에 JPA의 delete이용해서 삭제




- 지금부턴 수정사항이아님 기록용 article entity의 cascadetype.remove라는 옵션,
comment와 article을 onetomany로 매핑해서 article삭제시 commnet 자동삭제

공부했던것

JPA에서 Cascade란? -> 겁나 편리하다!! ( 노션에 다시 구체적 정리 예정 ) 

부모 엔티티(Parent)가 자식 엔티티(Child)를 참조할 때, 부모에 대한 영속성(Persistence) 작업을 자식까지 전이할지 여부를 정하는 것.
아들아 엄마따라 이거이거하쟈~~

종류에는


CascadeType.PERSIST : 부모 저장 시 → 자식도 자동 저장

CascadeType.MERGE : 부모 병합 시 → 자식도 자동 병합

CascadeType.REMOVE : 부모 삭제 시 → 자식도 자동 삭제

CascadeType.REFRESH : 부모 새로고침 시 → 자식도 같이 새로고침

CascadeType.DETACH : 부모 영속성 분리 시 → 자식도 같이 분리

CascadeType.ALL : 위 모든 동작을 자식에게 전이

등이있습니다..

Closes #11 